### PR TITLE
Remove --admin-port flag from deployment-operator

### DIFF
--- a/http-add-on/Chart.yaml
+++ b/http-add-on/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=v1.23.0-0"
 # to the chart and its templates, including the app version. This is incremented at chart release time and does not need
 # to be included in any PRs to main.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/http-add-on/templates/deployment-operator.yaml
+++ b/http-add-on/templates/deployment-operator.yaml
@@ -29,7 +29,7 @@ spec:
         app.kubernetes.io/name: {{ .Chart.Name }}-controller-manager
         {{- include "keda-addons-http.labels" . | indent 8 }}
     spec:
-      imagePullSecrets: 
+      imagePullSecrets:
         {{- toYaml .Values.operator.imagePullSecrets | nindent 8 }}
       serviceAccountName: {{ .Chart.Name }}
       containers:
@@ -50,7 +50,6 @@ spec:
       - args:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        - --admin-port={{ .Values.operator.adminPort }}
         image: "{{ .Values.images.operator }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         imagePullPolicy: '{{ .Values.operator.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-operator"
@@ -69,7 +68,7 @@ spec:
           value: "{{ .Release.Namespace }}"
         - name: KEDA_HTTP_OPERATOR_WATCH_NAMESPACE
           value: "{{ .Values.operator.watchNamespace }}"
-        ports: 
+        ports:
         - containerPort: {{ .Values.operator.adminPort }}
           name: admin-http
         resources:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
